### PR TITLE
Add Field type for ticket fields and custom_fields

### DIFF
--- a/zego/tickets.go
+++ b/zego/tickets.go
@@ -16,41 +16,41 @@ type SingleTicket struct {
 	Ticket *Ticket `json:"ticket"`
 }
 
-type CustomField struct {
+type Field struct {
 	Id    uint64      `json:"id"`
 	Value interface{} `json:"value"`
 }
 
 type Ticket struct {
-	Id                    uint64        `json:"id"`
-	URL                   string        `json:"url"`
-	ExternalId            string        `json:"external_id"`
-	CreatedAt             string        `json:"created_at"`
-	UpdatedAt             string        `json:"updated_at"`
-	Type                  string        `json:"type"`
-	Subject               string        `json:"subject"`
-	RawSubject            string        `json:"raw_subject"`
-	Description           string        `json:"description"`
-	Priority              string        `json:"priority"`
-	Status                string        `json:"status"`
-	Recipient             string        `json:"recipient"`
-	RequesterId           uint32        `json:"requester_id"`
-	SubmitterId           uint32        `json:"submitter_id"`
-	AssigneeId            uint32        `json:"assignee_id"`
-	OrganizationId        uint32        `json:"organization_id"`
-	GroupId               uint32        `json:"group_id"`
-	CollaboratorIds       []int32       `json:"collaborator_ids"`
-	ForumTopicId          uint32        `json:"forum_topic_id"`
-	ProblemId             uint32        `json:"problem_id"`
-	HasIncidents          bool          `json:"has_incidents"`
-	DueAt                 string        `json:"due_at"`
-	Tags                  []string      `json:"tags"`
-	Satisfaction_rating   string        `json:"satisfaction_rating"`
-	Ticket_form_id        uint32        `json:"ticket_form_id"`
-	Sharing_agreement_ids interface{}   `json:"sharing_agreement_ids"`
-	Via                   interface{}   `json:"via"`
-	Custom_Fields         []CustomField `json:"custom_fields"`
-	Fields                interface{}   `json:"fields"`
+	Id                    uint64      `json:"id"`
+	URL                   string      `json:"url"`
+	ExternalId            string      `json:"external_id"`
+	CreatedAt             string      `json:"created_at"`
+	UpdatedAt             string      `json:"updated_at"`
+	Type                  string      `json:"type"`
+	Subject               string      `json:"subject"`
+	RawSubject            string      `json:"raw_subject"`
+	Description           string      `json:"description"`
+	Priority              string      `json:"priority"`
+	Status                string      `json:"status"`
+	Recipient             string      `json:"recipient"`
+	RequesterId           uint32      `json:"requester_id"`
+	SubmitterId           uint32      `json:"submitter_id"`
+	AssigneeId            uint32      `json:"assignee_id"`
+	OrganizationId        uint32      `json:"organization_id"`
+	GroupId               uint32      `json:"group_id"`
+	CollaboratorIds       []int32     `json:"collaborator_ids"`
+	ForumTopicId          uint32      `json:"forum_topic_id"`
+	ProblemId             uint32      `json:"problem_id"`
+	HasIncidents          bool        `json:"has_incidents"`
+	DueAt                 string      `json:"due_at"`
+	Tags                  []string    `json:"tags"`
+	Satisfaction_rating   string      `json:"satisfaction_rating"`
+	Ticket_form_id        uint32      `json:"ticket_form_id"`
+	Sharing_agreement_ids interface{} `json:"sharing_agreement_ids"`
+	Via                   interface{} `json:"via"`
+	Custom_Fields         []Field     `json:"custom_fields"`
+	Fields                []Field     `json:"fields"`
 }
 
 func (a Auth) ListTickets(pag ...string) (*TicketArray, error) {

--- a/zego/tickets.go
+++ b/zego/tickets.go
@@ -16,36 +16,41 @@ type SingleTicket struct {
 	Ticket *Ticket `json:"ticket"`
 }
 
+type CustomField struct {
+	Id    uint64      `json:"id"`
+	Value interface{} `json:"value"`
+}
+
 type Ticket struct {
-	Id                    uint64      `json:"id"`
-	URL                   string      `json:"url"`
-	ExternalId            string      `json:"external_id"`
-	CreatedAt             string      `json:"created_at"`
-	UpdatedAt             string      `json:"updated_at"`
-	Type                  string      `json:"type"`
-	Subject               string      `json:"subject"`
-	RawSubject            string      `json:"raw_subject"`
-	Description           string      `json:"description"`
-	Priority              string      `json:"priority"`
-	Status                string      `json:"status"`
-	Recipient             string      `json:"recipient"`
-	RequesterId           uint32      `json:"requester_id"`
-	SubmitterId           uint32      `json:"submitter_id"`
-	AssigneeId            uint32      `json:"assignee_id"`
-	OrganizationId        uint32      `json:"organization_id"`
-	GroupId               uint32      `json:"group_id"`
-	CollaboratorIds       []int32     `json:"collaborator_ids"`
-	ForumTopicId          uint32      `json:"forum_topic_id"`
-	ProblemId             uint32      `json:"problem_id"`
-	HasIncidents          bool        `json:"has_incidents"`
-	DueAt                 string      `json:"due_at"`
-	Tags                  []string    `json:"tags"`
-	Satisfaction_rating   string      `json:"satisfaction_rating"`
-	Ticket_form_id        uint32      `json:"ticket_form_id"`
-	Sharing_agreement_ids interface{} `json:"sharing_agreement_ids"`
-	Via                   interface{} `json:"via"`
-	Custom_Fields         interface{} `json:"custom_fields"`
-	Fields                interface{} `json:"fields"`
+	Id                    uint64        `json:"id"`
+	URL                   string        `json:"url"`
+	ExternalId            string        `json:"external_id"`
+	CreatedAt             string        `json:"created_at"`
+	UpdatedAt             string        `json:"updated_at"`
+	Type                  string        `json:"type"`
+	Subject               string        `json:"subject"`
+	RawSubject            string        `json:"raw_subject"`
+	Description           string        `json:"description"`
+	Priority              string        `json:"priority"`
+	Status                string        `json:"status"`
+	Recipient             string        `json:"recipient"`
+	RequesterId           uint32        `json:"requester_id"`
+	SubmitterId           uint32        `json:"submitter_id"`
+	AssigneeId            uint32        `json:"assignee_id"`
+	OrganizationId        uint32        `json:"organization_id"`
+	GroupId               uint32        `json:"group_id"`
+	CollaboratorIds       []int32       `json:"collaborator_ids"`
+	ForumTopicId          uint32        `json:"forum_topic_id"`
+	ProblemId             uint32        `json:"problem_id"`
+	HasIncidents          bool          `json:"has_incidents"`
+	DueAt                 string        `json:"due_at"`
+	Tags                  []string      `json:"tags"`
+	Satisfaction_rating   string        `json:"satisfaction_rating"`
+	Ticket_form_id        uint32        `json:"ticket_form_id"`
+	Sharing_agreement_ids interface{}   `json:"sharing_agreement_ids"`
+	Via                   interface{}   `json:"via"`
+	Custom_Fields         []CustomField `json:"custom_fields"`
+	Fields                interface{}   `json:"fields"`
 }
 
 func (a Auth) ListTickets(pag ...string) (*TicketArray, error) {


### PR DESCRIPTION
Hi, 
I like the work you did so far but found the custom fields confusing.
As far as I can see, custom fields are always returned in the following JSON format:

```json
"custom_fields": [
 {
  "id": 25670032
  "value": null
 }
 {
  "id": 27192232
  "value": "test"
 }
]
```
The same goes for the Fields fields.

I have created a Field struct to hold these values which makes finding fields a whole lot easier.
The value is still of type interface{} so you need to cast that to the expected type, but it makes ranging the fields easier.

Also, I added this to you existing test, but that seemed broken and included itself so I fixed that as well.
